### PR TITLE
fix: fix disconnect due to incorrect message

### DIFF
--- a/src/main/java/cn/dancingsnow/dglab/api/Connection.java
+++ b/src/main/java/cn/dancingsnow/dglab/api/Connection.java
@@ -87,7 +87,7 @@ public class Connection {
     }
 
     public void disconnect() {
-        sendMessage(new DgLabMessage(DgLabMessageType.BREAK, clientId, targetId, ""));
+        sendMessage(new DgLabMessage(DgLabMessageType.BREAK, clientId, targetId, "209"));
         channel.close();
     }
 


### PR DESCRIPTION
According to https://github.com/DG-LAB-OPENSOURCE/DG-LAB-OPENSOURCE/blob/c3a425acc4c98adcf2a65184ffada433d41071c2/socket/BackEnd(Node)/websocketNode.js#L218, wsserver needs to send `209` when disconnecting. This PR fixes the issue that APP getting stuck after using the '/dglab disconnect' command to disconnect.