### PR TITLE
修改客户端使其允许接收来自插件服的自定义数据包

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,3 +117,6 @@ you can see the config file in `.minecraft/config/dglab.yml`, when you first sta
   * A String to set the ws address, if your computer and your phone installed `DG-LAB` in same LAN, can set it to `192.168.xx.xx` that your computer ip address
 - port (int)
   * the port to create ws server, and DG-LAB app will connect it.
+- bukkitCompatibilityMode (boolean)
+  * If true, DG-LAB payloads will be treated as optional channels, so the client can accept `dglab:*` custom payloads from non-NeoForge servers (e.g., Bukkit/Paper). Default: `false`.
+  * If your server is Bukkit/Paper and you have installed Minecraft-DG-LAB-Bukkit plugin, please set this option to `true`.

--- a/README_cn.md
+++ b/README_cn.md
@@ -115,3 +115,5 @@
   * 一个字符串来设置 WebSocket 连接地址，如果你的电脑和你的安装 DG-LAB 的手机在同一个局域网，可以设置此值为类似 `192.168.xx.xx`，这是你电脑的 ip 地址，可以运行 `ipconfig` 来查看。
 - port (int)
   * 运行 WebSocket Server 的端口，将会在这个端口的 WebSocket Server 和你的 DG-LAB APP 连接。
+- bukkitCompatibilityMode (boolean)
+  * Bukkit 兼容模式。如果设置为 `true`，客户端将允许接收来自非 NeoForge 服务器（如 Bukkit/Paper）的 `dglab:*` 自定义数据包。默认为 `false`。若您的服务器是 Bukkit/Paper 且安装了 Minecraft-DG-LAB-Bukkit 插件，请开启此选项。

--- a/src/main/java/cn/dancingsnow/dglab/config/ConfigHolder.java
+++ b/src/main/java/cn/dancingsnow/dglab/config/ConfigHolder.java
@@ -60,6 +60,15 @@ public class ConfigHolder {
         public boolean enabled = true;
 
         @Configurable
+        @Configurable.Comment({
+            "Bukkit 兼容模式。",
+            "如果启用，DG-LAB 的数据包将被视为可选通道，",
+            "使得客户端可以接收来自非 NeoForge 服务器（如 Bukkit/Paper）的 dglab:* 自定义数据包。",
+            "默认值：false"
+        })
+        public boolean bukkitCompatibilityMode = false;
+
+        @Configurable
         @Configurable.Comment({"The Gui Hud Scale", "Default: 1"})
         public float hudScale = 1;
 

--- a/src/main/java/cn/dancingsnow/dglab/networking/DgLabPackets.java
+++ b/src/main/java/cn/dancingsnow/dglab/networking/DgLabPackets.java
@@ -3,6 +3,7 @@ package cn.dancingsnow.dglab.networking;
 import cn.dancingsnow.dglab.DgLabMod;
 import cn.dancingsnow.dglab.api.Strength;
 import cn.dancingsnow.dglab.client.ClientData;
+import cn.dancingsnow.dglab.config.ConfigHolder;
 
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
@@ -13,13 +14,16 @@ import io.netty.buffer.ByteBuf;
 
 public class DgLabPackets {
     public static void init(PayloadRegistrar registrar) {
-        registrar.playToClient(
+        PayloadRegistrar r =
+                ConfigHolder.INSTANCE.client.bukkitCompatibilityMode ? registrar.optional() : registrar;
+
+        r.playToClient(
                 Strength.TYPE, Strength.STREAM_CODEC, (strength, ctx) -> ClientData.setStrength(strength));
 
-        registrar.playToClient(
+        r.playToClient(
                 ClearStrength.TYPE, ClearStrength.STREAM_CODEC, (c, ctx) -> ClientData.setStrength(null));
 
-        registrar.playToClient(
+        r.playToClient(
                 ShowQrCode.TYPE, ShowQrCode.STREAM_CODEC, (show, ctx) -> ClientData.setQrText(show.text()));
     }
 

--- a/src/main/resources/assets/dglab/lang/en_us.json
+++ b/src/main/resources/assets/dglab/lang/en_us.json
@@ -6,6 +6,7 @@
     "config.dglab.option.hudScale": "HUD Scale",
     "config.dglab.option.hudX": "HUD X",
     "config.dglab.option.hudY": "HUD Y",
+    "config.dglab.option.bukkitCompatibilityMode": "Bukkit Compatibility Mode",
     "config.dglab.option.port": "Port",
     "config.dglab.option.webSocket": "WebSocket Settings",
     "config.dglab.option.useHttps": "Use Https",

--- a/src/main/resources/assets/dglab/lang/zh_cn.json
+++ b/src/main/resources/assets/dglab/lang/zh_cn.json
@@ -6,6 +6,7 @@
     "config.dglab.option.hudScale": "HUD 缩放",
     "config.dglab.option.hudX": "HUD X",
     "config.dglab.option.hudY": "HUD Y",
+    "config.dglab.option.bukkitCompatibilityMode": "Bukkit 兼容模式",
     "config.dglab.option.port": "端口",
     "config.dglab.option.webSocket": "WebSocket 设置",
     "config.dglab.option.useHttps": "使用 Https",


### PR DESCRIPTION
写了个服务端插件 [Minecraft-DG-LAB-Bukkit](https://github.com/XUANHLGG/Minecraft-DG-LAB-Bukkit) ，使得 DG-LAB 的功能可以跨平台扩展到插件服务器
所以在客户端引入了一个新的配置项 bukkitCompatibilityMode ，打开后允许接收来自插件端的自定义数据包，因为 NeoForge 默认要求客户端和服务端双向注册自定义数据包通道